### PR TITLE
feat: add k8s templates, patch ALLOW_HOSTS

### DIFF
--- a/tutorphilu_extensions/patches/credentials-settings-production
+++ b/tutorphilu_extensions/patches/credentials-settings-production
@@ -1,0 +1,1 @@
+ALLOWED_HOSTS.append("*")

--- a/tutorphilu_extensions/patches/discovery-production-settings
+++ b/tutorphilu_extensions/patches/discovery-production-settings
@@ -1,0 +1,1 @@
+ALLOWED_HOSTS.append("*")

--- a/tutorphilu_extensions/patches/openedx-cms-production-settings
+++ b/tutorphilu_extensions/patches/openedx-cms-production-settings
@@ -1,0 +1,1 @@
+ALLOWED_HOSTS.append("*")

--- a/tutorphilu_extensions/patches/openedx-lms-production-settings
+++ b/tutorphilu_extensions/patches/openedx-lms-production-settings
@@ -1,0 +1,1 @@
+ALLOWED_HOSTS.append("*")

--- a/tutorphilu_extensions/plugin.py
+++ b/tutorphilu_extensions/plugin.py
@@ -145,6 +145,7 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
     [
         ("philu-extensions/build", "plugins"),
         ("philu-extensions/apps", "plugins"),
+        ("philu-extensions/k8s", "plugins"),
     ],
 )
 

--- a/tutorphilu_extensions/templates/philu-extensions/k8s/cron-jobs.yml
+++ b/tutorphilu_extensions/templates/philu-extensions/k8s/cron-jobs.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "discovery-cron-job-refresh_course_metadata"
+  namespace: "{{ K8S_NAMESPACE }}"
+spec:
+  schedule: "0 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: "discovery-refresh-course-metadata"
+              image: "{{ DISCOVERY_DOCKER_IMAGE }}"
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -c
+                - python ./manage.py refresh_course_metadata
+              volumeMounts:
+                - mountPath: /openedx/discovery/course_discovery/settings/tutor/production.py
+                  name: settings
+                  subPath: production.py
+          restartPolicy: Never
+          volumes:
+            - name: settings
+              configMap:
+                name: discovery-settings


### PR DESCRIPTION
Changes:
- add new k8s directory in templates
- add "*" to ALLOW_HOSTS for LMS/CMS/Discovery/Credentials

This is a quick change to test the CronJob, later we need to move schedule to some setting.