### PR TITLE
ci: [PhU-256] add three new waffle flags to be deactivated by default

### DIFF
--- a/tutorphilu_extensions/templates/philu-extensions/tasks/lms/init
+++ b/tutorphilu_extensions/templates/philu-extensions/tasks/lms/init
@@ -9,4 +9,7 @@
 (./manage.py lms waffle_switch --list | grep student.courseenrollment_admin) || ./manage.py lms waffle_switch --create student.courseenrollment_admin on
 
 ## Disabled by default Waffle flags
-(./manage.py lms waffle_flag --list | grep contentstore.enable_copy_paste_units) && ./manage.py lms waffle_flag --create --deactivate contentstore.enable_copy_paste_units
+(./manage.py lms waffle_flag --list | grep contentstore.enable_copy_paste_units) && ./manage.py lms waffle_flag --deactivate contentstore.enable_copy_paste_units
+(./manage.py lms waffle_flag --list | grep new_core_editors.use_new_problem_editor) && ./manage.py lms waffle_flag --deactivate new_core_editors.use_new_problem_editor
+(./manage.py lms waffle_flag --list | grep new_core_editors.use_new_text_editor) && ./manage.py lms waffle_flag --deactivate new_core_editors.use_new_text_editor
+(./manage.py lms waffle_flag --list | grep new_core_editors.use_new_video_editor) && ./manage.py lms waffle_flag --deactivate new_core_editors.use_new_video_editor


### PR DESCRIPTION
[PhU-256](https://youtrack.raccoongang.com/issue/PhU-256) Enabled by default MFE pages, flags, switches investigation

Fixes:
- remove incorrect --create option 

Added:
- added `new_core_editors.use_new_problem_editor` to be deactivated by default
- added `new_core_editors.use_new_text_editor` to be deactivated by default
- added `new_core_editors.use_new_video_editor` to be deactivated by default