### PR TITLE
fix: correct credentials service username

### DIFF
--- a/tutorphilu_extensions/patches/openedx-common-settings
+++ b/tutorphilu_extensions/patches/openedx-common-settings
@@ -13,3 +13,5 @@ COURSE_MODE_DEFAULTS = {
     'slug': 'honor',
     'suggested_prices': '',
 }
+
+CREDENTIALS_SERVICE_USERNAME = 'credentials'


### PR DESCRIPTION
YT:
- https://youtrack.raccoongang.com/issue/PhU-253

The issue is resolved in the upstream ([tutor-credentials](https://github.com/overhangio/tutor-credentials/issues/36)) but not included in any tagged version yet. 
We could get rid of the change when updating the plugin version