### PR TITLE
fix: favicon on mfe pages in safari

### DIFF
--- a/tutorphilu_extensions/patches/mfe-dockerfile-pre-npm-build
+++ b/tutorphilu_extensions/patches/mfe-dockerfile-pre-npm-build
@@ -1,3 +1,4 @@
 ENV LMS_BASE_URL={{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}
 ENV COOKIE_POLICY_COOKIE_DOMAIN=".{{ LMS_HOST }}"
 ENV SITE_NAME="{{ PLATFORM_NAME }}"
+ENV FAVICON_URL="{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/static/rg-theme/images/favicon-mfe.ico"

--- a/tutorphilu_extensions/plugin.py
+++ b/tutorphilu_extensions/plugin.py
@@ -166,10 +166,6 @@ for path in glob(str(importlib_resources.files("tutorphilu_extensions") / "patch
 hooks.Filters.ENV_PATCHES.add_items(
     [
         (
-            "mfe-dockerfile-pre-npm-build-discussions",
-            "ENV FAVICON_URL='{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/static/rg-theme/images/favicon-mfe.ico'"
-        ),
-        (
             "mfe-dockerfile-pre-npm-build-learner-record",
             "ENV USE_LR_MFE='true'"
         ),


### PR DESCRIPTION
Safari requires to set the favicon URL through
the mfe env.

Additionally remove related change from the Discussions MFE env (DRY).

YT:
- https://youtrack.raccoongang.com/issue/PhU-394